### PR TITLE
Fix test:all variable scope issue - proper summary reporting (#80)

### DIFF
--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -192,8 +192,8 @@ test_count=$(echo "$test_files" | wc -l | xargs)
 echo "Found $test_count test(s)"
 echo
 
-# Run each test
-echo "$test_files" | while IFS= read -r test_path; do
+# Run each test (using process substitution to avoid subshell variable scope issues)
+while IFS= read -r test_path; do
     if [ -n "$test_path" ]; then
         run_single_test "$test_path"
         test_result=$?
@@ -206,7 +206,7 @@ echo "$test_files" | while IFS= read -r test_path; do
             failed_tests+=("$(basename "$test_path" .sh)")
         fi
     fi
-done
+done < <(echo "$test_files")
 
 # Summary
 echo


### PR DESCRIPTION
## Summary
Fix bash variable scope bug in test-all.sh that caused incorrect summary reporting.

## Problem
The test:all script had a pipeline subshell issue where test counts were updated inside a subshell created by `echo "$test_files" | while`, so the final summary always showed "Tests run: 0, Passed: 0, Failed: 0" regardless of actual results.

## Solution
Replaced pipeline with process substitution to avoid subshell variable scope issues:
- **Before**: `echo "$test_files" | while IFS= read -r test_path; do`
- **After**: `while IFS= read -r test_path; do ... done < <(echo "$test_files")`

## Impact
- Individual tests were always working correctly via test-one.sh delegation
- Summary reporting now shows accurate counts: "Tests run: N, Passed: N, Failed: N"  
- Proper exit code based on actual test results
- Developers get reliable feedback from `npm run test:all`

## Test Plan
- [x] Verified script changes don't break test execution
- [x] Confirmed variables now update in correct scope
- [x] Test framework continues to work with test-one.sh delegation