### PR TITLE
Require sudo for ACL mutations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.11",
         "@types/js-yaml": "^4.0.9",
+        "@types/node": "^22.15.21",
         "@types/pg": "^8.20.0",
         "tsc-alias": "^1.8.16",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "devDependencies": {
         "@types/bun": "^1.3.11",
         "@types/js-yaml": "^4.0.9",
+        "@types/node": "^22.15.21",
         "@types/pg": "^8.20.0",
         "tsc-alias": "^1.8.16",
         "typescript": "^5.9.3"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,14 +54,14 @@ main() {
 
     # Step 1: TypeScript compilation
     log_info "Compiling TypeScript sources..."
-    if ! npx tsc; then
+    if ! bunx tsc; then
         log_error "TypeScript compilation failed"
         exit 1
     fi
 
     # Step 2: Resolve path aliases
     log_info "Resolving TypeScript path aliases..."
-    if ! npx tsc-alias; then
+    if ! bunx tsc-alias; then
         log_error "Path alias resolution failed"
         exit 1
     fi

--- a/spec/38-acls-api/acls-api.test.ts
+++ b/spec/38-acls-api/acls-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'bun:test';
 import { TestHelpers, type TestTenant } from '../test-helpers.js';
 import { expectSuccess, expectError } from '../test-assertions.js';
+import { HttpClient } from '../http-client.js';
 
 /**
  * ACLs API Tests
@@ -21,6 +22,8 @@ import { expectSuccess, expectError } from '../test-assertions.js';
 describe('ACLs API', () => {
     let tenant: TestTenant;
     let testRecordId: string;
+    let editClient: HttpClient;
+    let sudoClient: HttpClient;
 
     // Test UUIDs for ACL entries
     const uuid1 = '11111111-1111-1111-1111-111111111111';
@@ -31,7 +34,39 @@ describe('ACLs API', () => {
     const uuid6 = '66666666-6666-6666-6666-666666666666';
 
     beforeAll(async () => {
+        // Create tenant with root user
         tenant = await TestHelpers.createTestTenant('acls-api');
+
+        // Create a non-privileged edit user for authorization tests
+        const createEditUserResponse = await tenant.httpClient.post('/api/user', {
+            name: 'Edit User',
+            auth: 'edituser',
+            access: 'edit',
+        });
+        expectSuccess(createEditUserResponse);
+
+        const editUserToken = await TestHelpers.loginToTenant(tenant.tenantName, 'edituser');
+        editClient = new HttpClient('http://localhost:9001');
+        editClient.setAuthToken(editUserToken);
+
+        // Create a full user and elevate to sudo for privileged mutation tests
+        const createFullUserResponse = await tenant.httpClient.post('/api/user', {
+            name: 'Full User',
+            auth: 'fulluser',
+            access: 'full',
+        });
+        expectSuccess(createFullUserResponse);
+
+        const fullUserToken = await TestHelpers.loginToTenant(tenant.tenantName, 'fulluser');
+        const fullClient = new HttpClient('http://localhost:9001');
+        fullClient.setAuthToken(fullUserToken);
+        const sudoResponse = await fullClient.post('/api/user/sudo', {
+            reason: 'ACL mutation regression tests',
+        });
+        expectSuccess(sudoResponse);
+
+        sudoClient = new HttpClient('http://localhost:9001');
+        sudoClient.setAuthToken(sudoResponse.data.sudo_token);
 
         // Create test model
         await tenant.httpClient.post('/api/describe/accounts', {});
@@ -92,9 +127,39 @@ describe('ACLs API', () => {
         });
     });
 
+    describe('Privilege Enforcement', () => {
+        it('should reject ACL POST from non-sudo users', async () => {
+            const response = await editClient.post(`/api/acls/accounts/${testRecordId}`, {
+                access_read: [uuid1],
+            });
+
+            expectError(response);
+            expect(response.error_code).toBe('SUDO_REQUIRED');
+        });
+
+        it('should reject ACL PUT from non-sudo users', async () => {
+            const response = await editClient.put(`/api/acls/accounts/${testRecordId}`, {
+                access_read: [uuid1],
+                access_edit: [],
+                access_full: [],
+                access_deny: [],
+            });
+
+            expectError(response);
+            expect(response.error_code).toBe('SUDO_REQUIRED');
+        });
+
+        it('should reject ACL DELETE from non-sudo users', async () => {
+            const response = await editClient.delete(`/api/acls/accounts/${testRecordId}`);
+
+            expectError(response);
+            expect(response.error_code).toBe('SUDO_REQUIRED');
+        });
+    });
+
     describe('POST /api/acls/:model/:id - Append/Merge ACLs', () => {
         it('should add ACL entries', async () => {
-            const response = await tenant.httpClient.post(`/api/acls/accounts/${testRecordId}`, {
+            const response = await sudoClient.post(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid1, uuid2],
                 access_edit: [uuid3],
             });
@@ -107,7 +172,7 @@ describe('ACLs API', () => {
 
         it('should merge new entries with existing (not replace)', async () => {
             // Add more entries
-            const response = await tenant.httpClient.post(`/api/acls/accounts/${testRecordId}`, {
+            const response = await sudoClient.post(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid4], // New entry
                 access_edit: [uuid3], // Duplicate - should not be added twice
             });
@@ -127,7 +192,7 @@ describe('ACLs API', () => {
 
         it('should preserve existing fields when updating partial data', async () => {
             // Add only access_full, other fields should be preserved
-            const response = await tenant.httpClient.post(`/api/acls/accounts/${testRecordId}`, {
+            const response = await sudoClient.post(`/api/acls/accounts/${testRecordId}`, {
                 access_full: [uuid5],
             });
 
@@ -159,7 +224,7 @@ describe('ACLs API', () => {
 
     describe('PUT /api/acls/:model/:id - Replace ACLs', () => {
         it('should completely replace all ACL lists', async () => {
-            const response = await tenant.httpClient.put(`/api/acls/accounts/${testRecordId}`, {
+            const response = await sudoClient.put(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid6],
                 access_edit: [],
                 access_full: [],
@@ -177,7 +242,7 @@ describe('ACLs API', () => {
 
         it('should remove all previous ACL entries', async () => {
             // Verify original entries are gone
-            const response = await tenant.httpClient.get(`/api/acls/accounts/${testRecordId}`);
+            const response = await sudoClient.get(`/api/acls/accounts/${testRecordId}`);
 
             expectSuccess(response);
 
@@ -190,7 +255,7 @@ describe('ACLs API', () => {
 
         it('should set missing fields to empty arrays', async () => {
             // PUT with only access_read
-            const response = await tenant.httpClient.put(`/api/acls/accounts/${testRecordId}`, {
+            const response = await sudoClient.put(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid1],
             });
 
@@ -210,11 +275,11 @@ describe('ACLs API', () => {
             };
 
             // First PUT
-            const response1 = await tenant.httpClient.put(`/api/acls/accounts/${testRecordId}`, aclData);
+            const response1 = await sudoClient.put(`/api/acls/accounts/${testRecordId}`, aclData);
             expectSuccess(response1);
 
             // Second PUT with same data
-            const response2 = await tenant.httpClient.put(`/api/acls/accounts/${testRecordId}`, aclData);
+            const response2 = await sudoClient.put(`/api/acls/accounts/${testRecordId}`, aclData);
             expectSuccess(response2);
 
             // Results should be identical
@@ -225,7 +290,7 @@ describe('ACLs API', () => {
     describe('DELETE /api/acls/:model/:id - Clear ACLs', () => {
         it('should clear all ACLs', async () => {
             // First add some ACLs
-            await tenant.httpClient.post(`/api/acls/accounts/${testRecordId}`, {
+            await sudoClient.post(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid1, uuid2],
                 access_edit: [uuid3],
                 access_full: [uuid4],
@@ -233,7 +298,7 @@ describe('ACLs API', () => {
             });
 
             // Then clear them
-            const response = await tenant.httpClient.delete(`/api/acls/accounts/${testRecordId}`);
+            const response = await sudoClient.delete(`/api/acls/accounts/${testRecordId}`);
 
             expectSuccess(response);
 
@@ -270,20 +335,29 @@ describe('ACLs API', () => {
 
             expectError(response);
         });
+
+        it('should reject malformed UUIDs in ACL arrays', async () => {
+            const response = await sudoClient.post(`/api/acls/accounts/${testRecordId}`, {
+                access_read: ['not-a-uuid'],
+            });
+
+            expectError(response);
+            expect(response.error_code).toBe('INVALID_USER_ID_FORMAT');
+        });
     });
 
     describe('POST vs PUT Behavior Difference', () => {
         it('POST should merge, PUT should replace', async () => {
             // Clear ACLs first
-            await tenant.httpClient.delete(`/api/acls/accounts/${testRecordId}`);
+            await sudoClient.delete(`/api/acls/accounts/${testRecordId}`);
 
             // POST adds entries
-            await tenant.httpClient.post(`/api/acls/accounts/${testRecordId}`, {
+            await sudoClient.post(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid1],
             });
 
             // POST again should merge (additive)
-            const postResponse = await tenant.httpClient.post(`/api/acls/accounts/${testRecordId}`, {
+            const postResponse = await sudoClient.post(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid2],
             });
 
@@ -293,7 +367,7 @@ describe('ACLs API', () => {
             expect(postResponse.data.access_lists.access_read.length).toBe(2);
 
             // PUT should replace completely
-            const putResponse = await tenant.httpClient.put(`/api/acls/accounts/${testRecordId}`, {
+            const putResponse = await sudoClient.put(`/api/acls/accounts/${testRecordId}`, {
                 access_read: [uuid3],
             });
 

--- a/src/routes/api/acls/:model/:id/DELETE.ts
+++ b/src/routes/api/acls/:model/:id/DELETE.ts
@@ -1,4 +1,5 @@
 import { withTransaction } from '@src/lib/api-helpers.js';
+import { requireAclMutationAccess } from '../../acl-utils.js';
 
 /**
  * DELETE /api/acls/:model/:id - Clear all ACL lists
@@ -14,6 +15,8 @@ import { withTransaction } from '@src/lib/api-helpers.js';
  */
 export default withTransaction(async ({ system, params }) => {
     const { model, id } = params;
+
+    requireAclMutationAccess(system);
 
     // Verify record exists before updating (select404 automatically throws 404 if not found)
     await system.database.select404(model!, {

--- a/src/routes/api/acls/:model/:id/POST.ts
+++ b/src/routes/api/acls/:model/:id/POST.ts
@@ -1,5 +1,6 @@
 import { withTransaction } from '@src/lib/api-helpers.js';
 import { HttpErrors } from '@src/lib/errors/http-error.js';
+import { getAclFields, requireAclMutationAccess, validateAclFieldValues } from '../../acl-utils.js';
 
 /**
  * POST /api/acls/:model/:id - Merge ACL entries
@@ -16,23 +17,16 @@ import { HttpErrors } from '@src/lib/errors/http-error.js';
 export default withTransaction(async ({ system, params, body }) => {
     const { model, id } = params;
 
+    requireAclMutationAccess(system);
+
     // Validate request body structure
-    const validFields = ['access_read', 'access_edit', 'access_full', 'access_deny'];
+    const validFields = getAclFields();
     const updates: any = {};
     let hasValidUpdates = false;
 
     for (const field of validFields) {
         if (field in body) {
-            if (!Array.isArray(body[field])) {
-                throw HttpErrors.badRequest(`${field} must be an array`, 'INVALID_ACL_FORMAT');
-            }
-
-            // Validate all entries are strings (user IDs)
-            if (!body[field].every((userId: any) => typeof userId === 'string')) {
-                throw HttpErrors.badRequest(`${field} must contain only string user IDs`, 'INVALID_USER_ID_FORMAT');
-            }
-
-            updates[field] = body[field];
+            updates[field] = validateAclFieldValues(field, body[field]);
             hasValidUpdates = true;
         }
     }

--- a/src/routes/api/acls/:model/:id/PUT.ts
+++ b/src/routes/api/acls/:model/:id/PUT.ts
@@ -1,5 +1,6 @@
 import { withTransaction } from '@src/lib/api-helpers.js';
 import { HttpErrors } from '@src/lib/errors/http-error.js';
+import { getAclFields, requireAclMutationAccess, validateAclFieldValues } from '../../acl-utils.js';
 
 /**
  * PUT /api/acls/:model/:id - Replace ACL lists entirely
@@ -18,23 +19,17 @@ import { HttpErrors } from '@src/lib/errors/http-error.js';
 export default withTransaction(async ({ system, params, body }) => {
     const { model, id } = params;
 
+    requireAclMutationAccess(system);
+
     // Validate and prepare updates for all ACL fields
-    const validFields = ['access_read', 'access_edit', 'access_full', 'access_deny'];
+    const validFields = getAclFields();
     const updates: any = {};
 
     for (const field of validFields) {
         if (field in body) {
-            if (!Array.isArray(body[field])) {
-                throw HttpErrors.badRequest(`${field} must be an array`, 'INVALID_ACL_FORMAT');
-            }
-
-            // Validate all entries are strings (user IDs)
-            if (!body[field].every((userId: any) => typeof userId === 'string')) {
-                throw HttpErrors.badRequest(`${field} must contain only string user IDs`, 'INVALID_USER_ID_FORMAT');
-            }
-
+            const values = validateAclFieldValues(field, body[field]);
             // Remove duplicates
-            updates[field] = [...new Set(body[field])];
+            updates[field] = [...new Set(values)];
         } else {
             // Field not provided - set to empty array (complete replacement)
             updates[field] = [];

--- a/src/routes/api/acls/PUBLIC.md
+++ b/src/routes/api/acls/PUBLIC.md
@@ -14,8 +14,14 @@ Each record contains four access control arrays:
 
 All ACLs API operations require:
 - Valid JWT authentication
-- Admin or root level privileges
 - Target record must exist in the specified model
+
+ACL mutation operations require sudo access:
+- `POST /api/acls/:model/:record`
+- `PUT /api/acls/:model/:record`
+- `DELETE /api/acls/:model/:record`
+
+In practice, that means a root user, a caller with an active sudo token, or any other context the runtime marks as sudo.
 
 ## Endpoint Summary
 
@@ -137,7 +143,7 @@ When ACL arrays are empty (`[]`), the record uses default role-based permissions
 
 ## Security Notes
 
-- Only full and root users can modify ACLs
+- ACL mutation routes require sudo access
 - User IDs in ACL arrays must be valid UUID format strings
 - Duplicate user IDs are automatically removed
 - ACL changes take effect immediately

--- a/src/routes/api/acls/acl-utils.ts
+++ b/src/routes/api/acls/acl-utils.ts
@@ -1,0 +1,40 @@
+import { HttpErrors } from '@src/lib/errors/http-error.js';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ACL_FIELDS = ['access_read', 'access_edit', 'access_full', 'access_deny'] as const;
+
+export type AclField = (typeof ACL_FIELDS)[number];
+
+export function requireAclMutationAccess(system: { isSudo(): boolean }): void {
+    if (!system.isSudo()) {
+        throw HttpErrors.forbidden(
+            'Modifying record ACLs requires sudo access',
+            'SUDO_REQUIRED'
+        );
+    }
+}
+
+export function validateAclFieldValues(field: string, value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        throw HttpErrors.badRequest(`${field} must be an array`, 'INVALID_ACL_FORMAT');
+    }
+
+    if (!value.every((userId: unknown) => typeof userId === 'string')) {
+        throw HttpErrors.badRequest(`${field} must contain only string user IDs`, 'INVALID_USER_ID_FORMAT');
+    }
+
+    const invalidIds = value.filter((userId: string) => !UUID_REGEX.test(userId));
+    if (invalidIds.length > 0) {
+        throw HttpErrors.badRequest(
+            `${field} must contain valid UUID user IDs`,
+            'INVALID_USER_ID_FORMAT',
+            { field, invalid_ids: invalidIds }
+        );
+    }
+
+    return value;
+}
+
+export function getAclFields(): readonly AclField[] {
+    return ACL_FIELDS;
+}


### PR DESCRIPTION
## Summary\n- Require sudo access for ACL mutation routes\n- Validate ACL user IDs as UUIDs\n- Update ACL API tests and docs\n- Pin local TypeScript toolchain and add Node types\n\n## Verification\n- bun run build:packages\n- bunx tsc -p tsconfig.json --noEmit --pretty false