### PR TITLE
Enforce ACLs on data mutations

### DIFF
--- a/spec/32-data-api/data-acl-permissions.test.ts
+++ b/spec/32-data-api/data-acl-permissions.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+import { TestHelpers, type TestTenant } from '../test-helpers.js';
+import { expectSuccess, expectError } from '../test-assertions.js';
+import { HttpClient } from '../http-client.js';
+
+/**
+ * Data API ACL Mutation Tests
+ *
+ * Verifies record-level ACLs are enforced for write operations.
+ */
+
+describe('Data API ACL mutation enforcement', () => {
+    let tenant: TestTenant;
+    let readonlyClient: HttpClient;
+    let deniedClient: HttpClient;
+    let fullClient: HttpClient;
+
+    let readRecordId: string;
+    let deniedRecordId: string;
+    let fullRecordId: string;
+
+    const model = 'acl_documents';
+
+    beforeAll(async () => {
+        tenant = await TestHelpers.createTestTenant('data-acl');
+
+        // Create users representing the three permission levels we want to exercise.
+        const createReadUserResponse = await tenant.httpClient.post('/api/user', {
+            name: 'Read User',
+            auth: 'aclread',
+            access: 'read',
+        });
+        expectSuccess(createReadUserResponse);
+
+        const createEditUserResponse = await tenant.httpClient.post('/api/user', {
+            name: 'Edit User',
+            auth: 'acledit',
+            access: 'edit',
+        });
+        expectSuccess(createEditUserResponse);
+
+        const createFullUserResponse = await tenant.httpClient.post('/api/user', {
+            name: 'Full User',
+            auth: 'aclfull',
+            access: 'full',
+        });
+        expectSuccess(createFullUserResponse);
+
+        const readToken = await TestHelpers.loginToTenant(tenant.tenantName, 'aclread');
+        readonlyClient = new HttpClient('http://localhost:9001');
+        readonlyClient.setAuthToken(readToken);
+
+        const editToken = await TestHelpers.loginToTenant(tenant.tenantName, 'acledit');
+        deniedClient = new HttpClient('http://localhost:9001');
+        deniedClient.setAuthToken(editToken);
+
+        const fullToken = await TestHelpers.loginToTenant(tenant.tenantName, 'aclfull');
+        fullClient = new HttpClient('http://localhost:9001');
+        fullClient.setAuthToken(fullToken);
+
+        // Create model and fields.
+        await tenant.httpClient.post(`/api/describe/${model}`, {});
+        await tenant.httpClient.post(`/api/describe/${model}/fields/title`, {
+            field_name: 'title',
+            type: 'text',
+            required: true,
+        });
+        await tenant.httpClient.post(`/api/describe/${model}/fields/body`, {
+            field_name: 'body',
+            type: 'text',
+        });
+
+        // Record that only the read user can read, but cannot mutate.
+        const readRecord = await tenant.httpClient.post(`/api/data/${model}`, [{
+            title: 'Read-only record',
+            body: 'This record should be readable but not writable.',
+        }]);
+        expectSuccess(readRecord);
+        readRecordId = readRecord.data[0].id;
+        await tenant.httpClient.post(`/api/acls/${model}/${readRecordId}`, {
+            access_read: [createReadUserResponse.data.id],
+            access_edit: [],
+            access_full: [],
+            access_deny: [],
+        });
+
+        // Record that denies an edit-capable user.
+        const deniedRecord = await tenant.httpClient.post(`/api/data/${model}`, [{
+            title: 'Denied record',
+            body: 'This record should reject an editor because deny wins.',
+        }]);
+        expectSuccess(deniedRecord);
+        deniedRecordId = deniedRecord.data[0].id;
+        await tenant.httpClient.post(`/api/acls/${model}/${deniedRecordId}`, {
+            access_read: [],
+            access_edit: [createEditUserResponse.data.id],
+            access_full: [],
+            access_deny: [createEditUserResponse.data.id],
+        });
+
+        // Record that grants full access to the full user.
+        const fullRecord = await tenant.httpClient.post(`/api/data/${model}`, [{
+            title: 'Full-access record',
+            body: 'This record should support update/delete/revert/expire.',
+        }]);
+        expectSuccess(fullRecord);
+        fullRecordId = fullRecord.data[0].id;
+        await tenant.httpClient.post(`/api/acls/${model}/${fullRecordId}`, {
+            access_read: [],
+            access_edit: [],
+            access_full: [createFullUserResponse.data.id],
+            access_deny: [],
+        });
+    });
+
+    it('should let a read-only user fetch a record but not mutate it', async () => {
+        const readResponse = await readonlyClient.get(`/api/data/${model}/${readRecordId}`);
+        expectSuccess(readResponse);
+        expect(readResponse.data.title).toBe('Read-only record');
+
+        const updateResponse = await readonlyClient.put(`/api/data/${model}/${readRecordId}`, {
+            body: 'updated text',
+        });
+        expectError(updateResponse);
+        expect(updateResponse.error_code).toBe('ACCESS_DENIED');
+
+        const deleteResponse = await readonlyClient.delete(`/api/data/${model}/${readRecordId}`);
+        expectError(deleteResponse);
+        expect(deleteResponse.error_code).toBe('ACCESS_DENIED');
+    });
+
+    it('should deny a user when record ACLs explicitly deny them', async () => {
+        const updateResponse = await deniedClient.put(`/api/data/${model}/${deniedRecordId}`, {
+            body: 'denied update',
+        });
+        expectError(updateResponse);
+        expect(updateResponse.error_code).toBe('ACCESS_DENIED');
+
+        const deleteResponse = await deniedClient.delete(`/api/data/${model}/${deniedRecordId}`);
+        expectError(deleteResponse);
+        expect(deleteResponse.error_code).toBe('ACCESS_DENIED');
+    });
+
+    it('should allow a full-access user to update, delete, revert, and expire a record', async () => {
+        const updateResponse = await fullClient.put(`/api/data/${model}/${fullRecordId}`, {
+            body: 'updated by full user',
+        });
+        expectSuccess(updateResponse);
+        expect(updateResponse.data.body).toBe('updated by full user');
+
+        const deleteResponse = await fullClient.delete(`/api/data/${model}/${fullRecordId}`);
+        expectSuccess(deleteResponse);
+        expect(deleteResponse.data.trashed_at).toBeDefined();
+
+        const revertResponse = await fullClient.post(`/api/trashed/${model}/${fullRecordId}`);
+        expectSuccess(revertResponse);
+        expect(revertResponse.data.trashed_at).toBeNull();
+
+        const deleteAgainResponse = await fullClient.delete(`/api/data/${model}/${fullRecordId}`);
+        expectSuccess(deleteAgainResponse);
+
+        const expireResponse = await fullClient.delete(`/api/trashed/${model}/${fullRecordId}`);
+        expectSuccess(expireResponse);
+        expect(expireResponse.data.deleted_at).toBeDefined();
+    });
+});

--- a/src/lib/database/pipeline.ts
+++ b/src/lib/database/pipeline.ts
@@ -123,7 +123,7 @@ async function executeObserverPipeline(
     // Preload existing records for update/delete/revert/access operations
     // Single batch query, then single pass to set originals
     if (ids.length > 0) {
-        await preloadExistingRecords(model.model_name, records, ids, selectAnyFn);
+        await preloadExistingRecords(system, model.model_name, records, ids, selectAnyFn);
     }
 
     const runner = new ObserverRunner();
@@ -179,33 +179,44 @@ async function executeObserverPipeline(
  * @param selectAnyFn - Function to select records
  */
 async function preloadExistingRecords(
+    system: SystemContext,
     modelName: string,
     records: ModelRecord[],
     ids: string[],
     selectAnyFn: (modelName: string, filterData: any, options: SelectOptions) => Promise<any[]>
 ): Promise<void> {
-    // Batch query for existing records - include trashed for revert operations
-    const existingRows = await selectAnyFn(modelName, { where: { id: { $in: ids } } }, {
-        trashed: 'include',
-        context: 'system'
-    });
+    const wasAsSudo = typeof (system as any).isAsSudo === 'function' ? (system as any).isAsSudo() : false;
 
-    // Create lookup map by ID
-    const existingById = new Map(existingRows.map(row => [row.id, row]));
-
-    // Load original data into each ModelRecord
-    for (const record of records) {
-        const id = record.get('id');
-        const existing = existingById.get(id);
-
-        if (existing) {
-            record.load(existing);
-        }
+    if (typeof (system as any).setAsSudo === 'function') {
+        (system as any).setAsSudo(true);
     }
 
-    console.info('Preloaded existing records for pipeline', {
-        modelName,
-        requestedCount: ids.length,
-        foundCount: existingRows.length
-    });
+    try {
+        const existingRows = await selectAnyFn(modelName, { where: { id: { $in: ids } } }, {
+            trashed: 'include',
+            context: 'system'
+        });
+
+        const existingById = new Map(existingRows.map(row => [row.id, row]));
+
+        for (const record of records) {
+            const id = record.get('id');
+            const existing = existingById.get(id);
+
+            if (existing) {
+                record.load(existing);
+            }
+        }
+
+        console.info('Preloaded existing records for pipeline', {
+            modelName,
+            requestedCount: ids.length,
+            foundCount: existingRows.length
+        });
+    } finally {
+        if (typeof (system as any).setAsSudo === 'function') {
+            (system as any).setAsSudo(wasAsSudo);
+        }
+    }
 }
+

--- a/src/lib/mutation-access.ts
+++ b/src/lib/mutation-access.ts
@@ -1,11 +1,11 @@
 import type { ModelRecord } from '@src/lib/model-record.js';
 import { SecurityError } from '@src/lib/observers/errors.js';
 import type { SystemContext } from '@src/lib/system-context-types.js';
+import type { OperationType } from '@src/lib/observers/types.js';
 
 const ACL_FIELDS = ['access_read', 'access_edit', 'access_full', 'access_deny'] as const;
 
 type AclField = (typeof ACL_FIELDS)[number];
-type MutationOperation = 'update' | 'delete' | 'revert' | 'expire' | 'access';
 
 function asStringArray(value: unknown): string[] {
     return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
@@ -44,7 +44,7 @@ function canAccessMutation(system: SystemContext): boolean {
 export function authorizeRecordMutation(
     system: SystemContext,
     record: ModelRecord,
-    operation: MutationOperation
+    operation: OperationType
 ): void {
     if (operation === 'access') {
         if (!canAccessMutation(system)) {

--- a/src/lib/mutation-access.ts
+++ b/src/lib/mutation-access.ts
@@ -1,0 +1,76 @@
+import type { ModelRecord } from '@src/lib/model-record.js';
+import { SecurityError } from '@src/lib/observers/errors.js';
+import type { SystemContext } from '@src/lib/system-context-types.js';
+
+const ACL_FIELDS = ['access_read', 'access_edit', 'access_full', 'access_deny'] as const;
+
+type AclField = (typeof ACL_FIELDS)[number];
+type MutationOperation = 'update' | 'delete' | 'revert' | 'expire' | 'access';
+
+function asStringArray(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function recordAclValues(record: ModelRecord, field: AclField): string[] {
+    return asStringArray(record.old(field));
+}
+
+function isDenied(record: ModelRecord, userId: string): boolean {
+    return recordAclValues(record, 'access_deny').includes(userId);
+}
+
+function canUpdate(record: ModelRecord, userId: string): boolean {
+    return recordAclValues(record, 'access_edit').includes(userId) || recordAclValues(record, 'access_full').includes(userId);
+}
+
+function canDelete(record: ModelRecord, userId: string): boolean {
+    return recordAclValues(record, 'access_full').includes(userId);
+}
+
+function canAccessMutation(system: SystemContext): boolean {
+    return system.isSudo();
+}
+
+/**
+ * Enforce record-level mutation authorization.
+ *
+ * Rules:
+ * - sudo/root bypass all ACL checks
+ * - access_deny always wins for non-sudo callers
+ * - update requires access_edit or access_full
+ * - delete/revert/expire require access_full
+ * - access mutations require sudo
+ */
+export function authorizeRecordMutation(
+    system: SystemContext,
+    record: ModelRecord,
+    operation: MutationOperation
+): void {
+    if (operation === 'access') {
+        if (!canAccessMutation(system)) {
+            throw new SecurityError('Modifying record ACLs requires sudo access', undefined, 'SUDO_REQUIRED');
+        }
+        return;
+    }
+
+    if (system.isSudo()) {
+        return;
+    }
+
+    const userId = system.userId;
+
+    if (isDenied(record, userId)) {
+        throw new SecurityError('Record access denied', undefined, 'ACCESS_DENIED');
+    }
+
+    if (operation === 'update') {
+        if (!canUpdate(record, userId)) {
+            throw new SecurityError('Updating this record requires edit or full access', undefined, 'ACCESS_DENIED');
+        }
+        return;
+    }
+
+    if (!canDelete(record, userId)) {
+        throw new SecurityError('Deleting this record requires full access', undefined, 'ACCESS_DENIED');
+    }
+}

--- a/src/lib/observers/base-observer.ts
+++ b/src/lib/observers/base-observer.ts
@@ -11,6 +11,7 @@
 import type { Observer, ObserverContext } from '@src/lib/observers/interfaces.js';
 import type { ObserverRing, OperationType } from '@src/lib/observers/types.js';
 import {
+    ObserverError,
     ValidationError,
     BusinessLogicError,
     SystemError,
@@ -137,6 +138,10 @@ export abstract class BaseObserver implements Observer {
 
         } else if (error instanceof BusinessLogicError) {
             // Recoverable business logic errors - collect for user feedback
+            context.errors.push(error);
+
+        } else if (error instanceof ObserverError) {
+            // Recoverable observer errors - collect for user feedback
             context.errors.push(error);
 
         } else if (error instanceof SystemError || error instanceof ObserverTimeoutError) {

--- a/src/observers/all/2/50-existence-validator.ts
+++ b/src/observers/all/2/50-existence-validator.ts
@@ -18,6 +18,7 @@ import { ObserverRing } from '@src/lib/observers/types.js';
 export default class ExistenceValidator extends BaseObserver {
     readonly ring = ObserverRing.Security;
     readonly operations = ['update', 'delete', 'revert'] as const;
+    readonly priority = 40;
 
     async execute(context: ObserverContext): Promise<void> {
         const { operation, record } = context;

--- a/src/observers/all/2/50-soft-delete-protector.ts
+++ b/src/observers/all/2/50-soft-delete-protector.ts
@@ -20,6 +20,7 @@ import { ObserverRing } from '@src/lib/observers/types.js';
 export default class SoftDeleteProtector extends BaseObserver {
     readonly ring = ObserverRing.Security;
     readonly operations = ['update', 'delete'] as const;
+    readonly priority = 50;
 
     async execute(context: ObserverContext): Promise<void> {
         const { operation, record } = context;

--- a/src/observers/all/2/60-record-mutation-authorizer.ts
+++ b/src/observers/all/2/60-record-mutation-authorizer.ts
@@ -1,0 +1,26 @@
+import { BaseObserver } from '@src/lib/observers/base-observer.js';
+import { ObserverRing } from '@src/lib/observers/types.js';
+import type { ObserverContext } from '@src/lib/observers/interfaces.js';
+import { authorizeRecordMutation } from '@src/lib/mutation-access.js';
+
+/**
+ * Record Mutation Authorizer
+ *
+ * Enforces record-level ACL checks before any mutation reaches ring 5.
+ *
+ * Rules:
+ * - sudo/root callers bypass record ACL checks
+ * - access_deny always wins for non-sudo callers
+ * - update requires access_edit or access_full
+ * - delete/revert/expire require access_full
+ * - access mutations require sudo
+ */
+export default class RecordMutationAuthorizer extends BaseObserver {
+    readonly ring = ObserverRing.Security;
+    readonly operations = ['update', 'delete', 'revert', 'expire', 'access'] as const;
+    readonly priority = 60;
+
+    async execute(context: ObserverContext): Promise<void> {
+        authorizeRecordMutation(context.system, context.record, context.operation);
+    }
+}

--- a/src/observers/registry.ts
+++ b/src/observers/registry.ts
@@ -41,6 +41,7 @@ import EmailValidation from '@src/observers/users/1/50-email-validation.js';
 // =============================================================================
 import ExistenceValidator from '@src/observers/all/2/50-existence-validator.js';
 import SoftDeleteProtector from '@src/observers/all/2/50-soft-delete-protector.js';
+import RecordMutationAuthorizer from '@src/observers/all/2/60-record-mutation-authorizer.js';
 
 // =============================================================================
 // Ring 3: Business Logic
@@ -135,6 +136,7 @@ export const observers: Observer[] = [
     // Ring 2: Security
     new ExistenceValidator(),
     new SoftDeleteProtector(),
+    new RecordMutationAuthorizer(),
 
     // Ring 3: Business Logic
     new DuplicateFieldChecker(),


### PR DESCRIPTION
## Summary\n- Enforce record-level ACL checks on data mutations\n- Add mutation authorization observer and helper\n- Add regression coverage for read-only, denied, and full-access callers\n- Merge in the ACL build/toolchain fix from issue 252\n\n## Verification\n- bun run build:packages\n- bunx tsc -p tsconfig.json --noEmit --pretty false